### PR TITLE
fix(observability): normalize granular run types to API schema

### DIFF
--- a/app/src/lib/observability/clickhouse-client.ts
+++ b/app/src/lib/observability/clickhouse-client.ts
@@ -46,13 +46,15 @@ const isRunType = (value: unknown): value is RunType =>
 function normalizeRunType(value: unknown): RunType | undefined {
   if (typeof value !== "string") return undefined;
 
-  // Map new granular types to existing enum
+  // Map new granular types to existing enum, pass through canonical values
   switch (value) {
     case "playwright_job":
     case "playwright_test":
+    case "playwright":
       return "playwright";
     case "k6_job":
     case "k6_test":
+    case "k6":
       return "k6";
     case "job":
     case "monitor":


### PR DESCRIPTION
Maps worker-emitted granular run types back to API-compatible enum values to maintain schema compatibility. The worker now emits playwright_job, playwright_test, k6_job, k6_test but the API expects playwright, k6, job, monitor. This normalization ensures traces/logs are properly handled and filtered without breaking validation or queries.

Mapping:
- playwright_job, playwright_test → playwright
- k6_job, k6_test → k6
- job, monitor → unchanged

Fixes Codex review P1 issue about schema mismatch.
